### PR TITLE
changed artefacts to artifacts

### DIFF
--- a/ECRExpander/README.md
+++ b/ECRExpander/README.md
@@ -96,10 +96,10 @@ Resources:
 
 ## Installation
 
-As the source code is in a separate file, you will need to package the CloudFormation template first. You can do so with the below command, where you replace `${ARTEFACTS_BUCKET}` with the S3 bucket you wish to use for temporary storing the zipped file.
+As the source code is in a separate file, you will need to package the CloudFormation template first. You can do so with the below command, where you replace `${ARTIFACTS_BUCKET}` with the S3 bucket you wish to use for temporary storing the zipped file.
 
 ```bash
-aws cloudformation package --template-file ./macro-template.yml --s3-bucket ${ARTEFACTS_BUCKET} --output-template-file packaged-macro.yml
+aws cloudformation package --template-file ./macro-template.yml --s3-bucket ${ARTIFACTS_BUCKET} --output-template-file packaged-macro.yml
 ```
 
 After this you can then deploy the packaged-macro.yml CloudFormation template using a regular CloudFormation deployment. From the CLI this would mean:

--- a/NaclExpander/README.md
+++ b/NaclExpander/README.md
@@ -86,10 +86,10 @@ Resources:
 
 ## Deployment
 
-As the source code is in a separate file, you will need to package the CloudFormation template first. You can do so with the below command, where you replace `${ARTEFACTS_BUCKET}` with the S3 bucket you wish to use for temporary storing the zipped file.
+As the source code is in a separate file, you will need to package the CloudFormation template first. You can do so with the below command, where you replace `${ARTIFACTS_BUCKET}` with the S3 bucket you wish to use for temporary storing the zipped file.
 
 ```bash
-aws cloudformation package --template-file ./macro-template.yml --s3-bucket ${ARTEFACTS_BUCKET} --output-template-file packaged-macro.yml
+aws cloudformation package --template-file ./macro-template.yml --s3-bucket ${ARTIFACTS_BUCKET} --output-template-file packaged-macro.yml
 ```
 
 After this you can then deploy the packaged-macro.yml CloudFormation template using a regular CloudFormation deployment. From the CLI this would mean:

--- a/SSOFixer/README.md
+++ b/SSOFixer/README.md
@@ -52,10 +52,10 @@ The default implementation of the SSO Assignment means you have to use internal 
 
 ## Deployment
 
-As the source code is in a separate file, you will need to package the CloudFormation template first. You can do so with the below command, where you replace `${ARTEFACTS_BUCKET}` with the S3 bucket you wish to use for temporary storing the zipped file.
+As the source code is in a separate file, you will need to package the CloudFormation template first. You can do so with the below command, where you replace `${ARTIFACTS_BUCKET}` with the S3 bucket you wish to use for temporary storing the zipped file.
 
 ```bash
-aws cloudformation package --template-file ./macro-template.yml --s3-bucket ${ARTEFACTS_BUCKET} --output-template-file packaged-macro.yml
+aws cloudformation package --template-file ./macro-template.yml --s3-bucket ${ARTIFACTS_BUCKET} --output-template-file packaged-macro.yml
 ```
 
 After this you can then deploy the packaged-macro.yml CloudFormation template using a regular CloudFormation deployment. From the CLI this would mean:


### PR DESCRIPTION
A meaningless change, but more accustomed to the American English spelling of artifacts. Anecdotally, it seems to be a common battle [over use of the spelling.](https://writingexplained.org/artefact-vs-artifact-difference)

Otherwise, looks great!